### PR TITLE
Workaround hack so it can be used from an external crate

### DIFF
--- a/miniz-sys/build.rs
+++ b/miniz-sys/build.rs
@@ -1,7 +1,16 @@
 use std::process::Command;
+use std::path::Path;
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStringExt;
 
 fn main() {
     Command::new("./miniz_oxide/build.sh").status().unwrap();
-    let out_dir = "miniz-sys/miniz_oxide";
-    println!("cargo:rustc-link-search=native={}", out_dir);
+    let cur_dir = {
+        let cur_dir = Command::new("pwd").output().unwrap().stdout;
+        let n = cur_dir.len();
+        // Strip the newline.
+        Vec::from(&cur_dir[..n - 1])
+    };
+    let out_dir = Path::new(&OsString::from_vec(cur_dir)).join("miniz_oxide");
+    println!("cargo:rustc-link-search=native={}", out_dir.to_str().unwrap());
 }


### PR DESCRIPTION
This is a small hack to make it usable from a different crate. Without this the build fails as it can't find libminiz_oxide when added as a dependency. 

I used this to see how it compared, so I thought it might be useful.